### PR TITLE
検索ページ関連の修正

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,7 +5,7 @@ import { twMerge } from 'tailwind-merge';
 export type Card = {
   href: string;
   title: string;
-  date: Date;
+  date: Date | string;
   tags: string[];
   img?: string;
 };

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,6 +2,12 @@ import type { FC } from 'react';
 import { formatDate } from '@utils/formatDate';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Card コンポーネントは Astro での HTML ビルド時と、検索結果の表示のために React から呼び出される
+ * 両対応にするために tsx ファイルとしている。
+ * また、Astro が読み出す MarkDown コンテンツと、Pagefind の検索結果の2つがデータソースになる。
+ */
+
 export type Card = {
   href: string;
   title: string;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -16,7 +16,7 @@ const Card: FC<Card> = ({ href, title, date, tags, img }) => {
       <h3 className="mb-8 px-8 text-18 font-semibold">{title}</h3>
       <p className="px-8 font-space-grotesk text-14 text-fg-400">{formatDate(date)}</p>
       <ul className="flex flex-wrap px-8 font-inter text-14 text-fg-400">
-        {tags.map((tag) => (
+        {tags?.map((tag) => (
           <li key={tag} className='after:mr-2 after:content-[","] last:after:content-none'>
             {tag}
           </li>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -28,6 +28,7 @@ const SearchInput: FC<Props> = ({ className }) => {
         return {
           href: data.url,
           title: data.meta.title,
+          date: data.meta.pubDate
         };
       }),
     );

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -21,6 +21,7 @@ const SearchResults:FC = () => {
           return {
             href: data.url,
             title: data.meta.title,
+            date: data.meta.pubDate
           };
         }),
       );

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -2,33 +2,36 @@ import Card from '@components/Card'
 import { pageFindAtom, resultsAtom } from '@libs/jotai'
 import { useAtom, useAtomValue } from 'jotai'
 import { type FC, useEffect  } from 'react'
+import dummyResult from '@libs/dummyResult';
 
 const SearchResults:FC = () => {
   const [results,setResults] = useAtom(resultsAtom)
   const pagefind = useAtomValue(pageFindAtom)
 
   useEffect(()=>{
-    if( import.meta.env.DEV ) return
-
     const find = async () => {
       const query = new URLSearchParams(document.location.search || '')
       const searchWord = query.get("keyword") || ''
-      const search = await pagefind.search(searchWord);
-
-      const results = await Promise.all(
-        search.results.map(async (r: any) => {
-          const data = await r.data();
-          return {
-            href: data.url,
-            title: data.meta.title,
-            date: data.meta.pubDate
-          };
-        }),
-      );
-      setResults(results)
+      if( import.meta.env.DEV && searchWord ) {
+        setResults(dummyResult());
+      } else {
+        const search = await pagefind.search(searchWord);
+        const results = await Promise.all(
+          search.results.map(async (r: any) => {
+            const data = await r.data();
+            return {
+              href: data.url,
+              title: data.meta.title,
+              date: data.meta.pubDate
+            };
+          }),
+        );
+        setResults(results)
+      }
     }
 
     find()
+
   }, [])
 
   return results && (

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -34,7 +34,12 @@ const SearchResults:FC = () => {
 
   }, [])
 
-  return results && (
+  return results.length === 0
+    ? (
+    <div>
+      該当する記事はありません
+    </div>
+    ) : (
     <div>
       { results.map((result)=>{
           return <Card {...result}/>

--- a/src/libs/dummyResult.ts
+++ b/src/libs/dummyResult.ts
@@ -1,7 +1,7 @@
 // ビルドしないとPagefindのインデックスやJSが生成されない
 // 開発環境では適当に0～3つのPostを返す
 const dummyResult = () => {
-  const max = Math.ceil( ( Math.random() * 10 ) ) - 3
+  const max = Math.floor( Math.random() * 4 )
   const stub = [
       {
         href: "#",

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -57,7 +57,7 @@ const { title, description, upDate, pubDate, author, image, tags = [] } = entry.
     <aside class={twMerge('col-span-4 col-start-9 row-span-2 row-start-1 grid grid-rows-subgrid border-x')}>
       <div>
         <time datetime={upDate.toISOString()}>{formatDate(upDate)}</time>
-        <time datetime={pubDate.toISOString()}>{formatDate(pubDate)}</time>
+        <time datetime={pubDate.toISOString()} data-pagefind-meta="pubDate">{formatDate(pubDate)}</time>
         <ul>
           {
             (tags ?? []).map((tag: string | undefined) => {

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,4 +2,8 @@
  * 日付を「2024.06.01」のような形式に変換する関数
  */
 
-export const formatDate = (date: Date): string => date.toLocaleDateString('ja-JP').replace(/\//g, '.');
+export const formatDate = (date: Date | string ): string => {
+  return typeof date === 'string'
+    ? date
+    : date.toLocaleDateString('ja-JP').replace(/\//g, '.')
+}


### PR DESCRIPTION
@git-hub-tomosan 検索ページ関連を修正しました。
`tomo/dev` 宛に出しているので、マージ後はそのまま続きのコーディングお願いします。

 * `/search` ページで検索結果が表示されない不具合修正
   * 日付は検索結果で出力していなかったので、出力するよう実装
   * 開発環境でダミーの検索結果を出力するように実装しました
 * `Tag` プロパティは空の場合にエラーが出るので対応
   * 空欄を許容する定義にしてあります、ページ生成に絶対必須でもないため
   * https://github.com/kiteretz/hyacker/blob/e074df4c495563e2f07c50df16ef95a96e989256/src/content.config.ts#L22
